### PR TITLE
Add basic LLM-powered Telegram userbot scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.session
+userbot/logs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# chatgpt
+# Telegram LLM Userbot Skeleton
+
+This repository contains a minimal userbot powered by a local large language model.
+It is not a full application, but a starting point for further development.
+
+## Features
+
+- Connects to Telegram using **Telethon**.
+- Sends messages to a local LLM server (e.g. Ollama, LM Studio).
+- Reads a system prompt from `userbot/prompts/system_prompt.txt` on every message.
+- Logs conversations to `userbot/logs/history.jsonl`.
+- Simple whitelist/blacklist via `userbot/config.yaml`.
+
+## Setup
+
+1. Create a Telegram API application to obtain `api_id` and `api_hash`.
+2. Edit `userbot/config.yaml` with your credentials and LLM endpoint.
+3. Install requirements:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Run the bot:
+
+   ```bash
+   python -m userbot.bot
+   ```
+
+The bot will start a new session on first launch and listen for incoming messages.
+Only users allowed by the whitelist will receive responses.
+
+## Notes
+
+- The project is a simplified example and lacks the GUI and fine-tuning tools
+  described in the original specification.
+- LLM requests are sent to the configured HTTP endpoint; adjust the payload in
+  `userbot/llm.py` for your model.
+- Prompts can be hot-reloaded by editing the text file while the bot is running.
+
+Contributions are welcome!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+telethon>=1.29.0
+PyYAML>=6.0
+requests>=2.31.0

--- a/userbot/__main__.py
+++ b/userbot/__main__.py
@@ -1,0 +1,5 @@
+from .bot import main
+
+if __name__ == '__main__':
+    import asyncio
+    asyncio.run(main())

--- a/userbot/bot.py
+++ b/userbot/bot.py
@@ -1,0 +1,70 @@
+import asyncio
+import json
+from pathlib import Path
+from datetime import datetime
+
+from telethon import TelegramClient, events
+import yaml
+
+from .llm import generate, load_config
+
+
+CONFIG_PATH = Path(__file__).resolve().parent / 'config.yaml'
+PROMPT_PATH = Path(__file__).resolve().parent / 'prompts' / 'system_prompt.txt'
+
+
+def read_prompt() -> str:
+    try:
+        with open(PROMPT_PATH, 'r') as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def log_interaction(user_id: int, message: str, response: str, log_file: Path):
+    log_entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user_id": user_id,
+        "message": message,
+        "response": response,
+    }
+    with open(log_file, 'a') as lf:
+        lf.write(json.dumps(log_entry) + "\n")
+
+
+async def main():
+    config = load_config()
+    api_id = config['telegram']['api_id']
+    api_hash = config['telegram']['api_hash']
+    session = config['telegram']['session']
+
+    log_file = Path(config['log_file'])
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    client = TelegramClient(session, api_id, api_hash)
+
+    whitelist = set(config['telegram'].get('whitelist', []))
+    blacklist = set(config['telegram'].get('blacklist', []))
+
+    @client.on(events.NewMessage(outgoing=False))
+    async def handler(event):
+        sender = await event.get_sender()
+        sender_id = sender.id
+        if blacklist and sender_id in blacklist:
+            return
+        if whitelist and sender_id not in whitelist:
+            return
+
+        text = event.raw_text
+        prompt = read_prompt() + "\n" + text
+        response = generate(prompt)
+        await event.reply(response)
+        log_interaction(sender_id, text, response, log_file)
+
+    async with client:
+        print("Userbot started. Press Ctrl+C to stop.")
+        await client.run_until_disconnected()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/userbot/config.yaml
+++ b/userbot/config.yaml
@@ -1,0 +1,11 @@
+# Basic configuration for the Telegram userbot
+telegram:
+  api_id: YOUR_API_ID
+  api_hash: YOUR_API_HASH
+  session: session.session
+  whitelist: []  # list of allowed user ids
+  blacklist: []  # list of blocked user ids
+llm:
+  endpoint: http://localhost:11434/api/generate
+  model: llama2
+log_file: logs/history.jsonl

--- a/userbot/llm.py
+++ b/userbot/llm.py
@@ -1,0 +1,27 @@
+import requests
+from pathlib import Path
+import yaml
+
+CONFIG_PATH = Path(__file__).resolve().parent / 'config.yaml'
+
+
+def load_config():
+    with open(CONFIG_PATH, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def generate(prompt: str, temperature: float = 0.7) -> str:
+    config = load_config()
+    data = {
+        "model": config['llm']['model'],
+        "prompt": prompt,
+        "temperature": temperature,
+        "stream": False,
+    }
+    try:
+        resp = requests.post(config['llm']['endpoint'], json=data, timeout=60)
+        resp.raise_for_status()
+        res = resp.json()
+        return res.get('response') or res.get('choices', [{}])[0].get('text', '')
+    except Exception as e:
+        return f"[LLM error: {e}]"

--- a/userbot/prompts/system_prompt.txt
+++ b/userbot/prompts/system_prompt.txt
@@ -1,0 +1,1 @@
+You are a helpful LLM assistant integrated into a Telegram userbot.


### PR DESCRIPTION
## Summary
- add Python userbot module using Telethon
- integrate simple HTTP-based LLM helper
- allow system prompt hot reloading and conversation logging
- document setup and usage in README

## Testing
- `python -m compileall -q userbot`


------
https://chatgpt.com/codex/tasks/task_e_68479b3b8e98832dba0926c0fbf227ff